### PR TITLE
testing&verification: check simulateion results of refactored validator-manager

### DIFF
--- a/.github/workflows/apply-scoring.yml
+++ b/.github/workflows/apply-scoring.yml
@@ -108,6 +108,20 @@ jobs:
           SCORES_CSV: ${{ env.scores_csv }}
           IMAGE_TAG: ${{ env.latest }}
 
+      - name: Run scoring - simulation - refactored validator-manager
+        run: |
+          docker run --rm --user "$(id -u):$(id -g)" \
+            -v /tmp/solana-config.yml:/.config/solana/cli/config.yml \
+            -v /tmp/id.json:/.config/solana/id.json \
+            -v "$(realpath "$SCORES_CSV"):/scores.csv" \
+            "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+            ./validator-manager -s update-scores2 --scores-file /scores.csv
+        env:
+          SCORES_CSV: ${{ env.scores_csv }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: marinade.finance/validator-manager
+          IMAGE_TAG: f367f41
+
       - name: Run scoring
         run: |
           docker run --rm --user "$(id -u):$(id -g)" \
@@ -251,6 +265,20 @@ jobs:
           ECR_REPOSITORY: marinade.finance/marinade-anchor
           UNSTAKE_HINTS_JSON: ${{ env.unstake_hints_json }}
           IMAGE_TAG: ${{ env.latest }}
+
+      - name: Emergency unstake - simulation - refactored validator-manager
+        run: |
+          <"$UNSTAKE_HINTS_JSON" jq '.unstake_hints[].vote_account' -r | xargs -I{} \
+            docker run --rm --user "$(id -u):$(id -g)" \
+              -v /tmp/solana-config.yml:/.config/solana/cli/config.yml \
+              -v /tmp/id.json:/.config/solana/id.json \
+              "$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" \
+              ./validator-manager -s emergency-unstake {}
+        env:
+          UNSTAKE_HINTS_JSON: ${{ env.unstake_hints_json }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: marinade.finance/validator-manager
+          IMAGE_TAG: f367f41
 
       - name: Emergency unstake
         run: |


### PR DESCRIPTION
For verification purposes of the refactored bot CLI of validator-manager
(old version from marinade-anchor https://github.com/marinade-finance/marinade-anchor/tree/main/cli, refatored version https://github.com/marinade-finance/validator-manager)
adding simulation with refactored version of the bot.
The image was built at https://build.marinade.finance/job/validator-manager/1/console

This code change is only temporary and will be removed when old bot is deprecated.