### PR TITLE
[INC-47] pin GitHub Actions to SHA and ubuntu-24.04

### DIFF
--- a/.github/workflows/apply-scoring.yml
+++ b/.github/workflows/apply-scoring.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   apply_scoring:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'scoring/'))
 
     steps:
@@ -19,7 +19,7 @@ jobs:
           echo "start_timestamp=$start_timestamp" >> $GITHUB_ENV
 
       - name: Checkout the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
         with:
           ref: master
           fetch-depth: 20
@@ -62,7 +62,7 @@ jobs:
           echo "epoch=$epoch" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -70,7 +70,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
       - name: Prepare solana config
         run: |
@@ -162,7 +162,7 @@ jobs:
             DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
 
       # - name: Approval stage
-      #   uses: trstringer/manual-approval@v1
+      #   uses: trstringer/manual-approval@74d99dff7380e3e4b122d4ededcbca2b6ce59367 # v1
       #   with:
       #     secret: ${{ github.TOKEN }}
       #     approvers: user1,user2,org-team1
@@ -175,10 +175,10 @@ jobs:
 
   # emergency_unstake:
   #   needs: apply_scoring
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   steps:
   #     - name: Checkout the repository
-  #       uses: actions/checkout@master
+  #       uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
   #       with:
   #         ref: master
   #         fetch-depth: 20
@@ -206,7 +206,7 @@ jobs:
   #         echo "epoch=$epoch" >> $GITHUB_ENV
 
   #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
+  #       uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
   #       with:
   #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
   #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -214,7 +214,7 @@ jobs:
 
   #     - name: Login to Amazon ECR
   #       id: login-ecr
-  #       uses: aws-actions/amazon-ecr-login@v1
+  #       uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
   #     - name: Prepare solana config
   #       run: |

--- a/.github/workflows/prepare-scoring.yml
+++ b/.github/workflows/prepare-scoring.yml
@@ -7,7 +7,7 @@ on:
 
 jobs: 
   scoring:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Set start timestamp
@@ -15,9 +15,9 @@ jobs:
         start_timestamp=$(date +%s)
         echo "start_timestamp=$start_timestamp" >> $GITHUB_ENV
 
-    - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v2
-    - uses: r-lib/actions/setup-pandoc@v2
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
+    - uses: r-lib/actions/setup-r@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
+    - uses: r-lib/actions/setup-pandoc@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
       with:
         pandoc-version: 3.1.1
     - run: |
@@ -26,7 +26,7 @@ jobs:
         Version: 0.0.1
         EOF
 
-    - uses: r-lib/actions/setup-r-dependencies@v2
+    - uses: r-lib/actions/setup-r-dependencies@6f6e5bc62fba3a704f74e7ad7ef7676c5c6a2590 # v2
       with:
         extra-packages: |
           any::dotenv

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   trigger_scoring_if_needed:
     name: Schedule Scoring
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@master
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - name: Check epoch timing
       run: |
         epoch_info=$(curl -sfLS "http://api.mainnet-beta.solana.com" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}')

--- a/.github/workflows/v2-apply-scoring.yml
+++ b/.github/workflows/v2-apply-scoring.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   apply_scoring_v2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'scoring/'))
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
         with:
           fetch-depth: 20
 
@@ -84,10 +84,10 @@ jobs:
   # Temporary disable and apply them manually
   # early_unstake:
   #   needs: apply_scoring_v2
-  #   runs-on: ubuntu-latest
+  #   runs-on: ubuntu-24.04
   #   steps:
   #     - name: Checkout the repository
-  #       uses: actions/checkout@master
+  #       uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
   #       with:
   #         fetch-depth: 20
 
@@ -114,7 +114,7 @@ jobs:
   #         echo "epoch=$epoch" >> $GITHUB_ENV
 
   #     - name: Configure AWS credentials
-  #       uses: aws-actions/configure-aws-credentials@v1
+  #       uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
   #       with:
   #         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
   #         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -122,7 +122,7 @@ jobs:
 
   #     - name: Login to Amazon ECR
   #       id: login-ecr
-  #       uses: aws-actions/amazon-ecr-login@v1
+  #       uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
   #     - name: Prepare solana config
   #       run: |

--- a/.github/workflows/v2-apply-unstakes.yml
+++ b/.github/workflows/v2-apply-unstakes.yml
@@ -11,10 +11,10 @@ on:
 jobs:
   late_unstake:
     if: startsWith(github.event.pull_request.head.ref, 'unstakes') && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
         with:
           fetch-depth: 20
 
@@ -41,7 +41,7 @@ jobs:
           echo "epoch=$epoch" >> $GITHUB_ENV
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
       - name: Prepare solana config
         run: |

--- a/.github/workflows/v2-prepare-scoring.yml
+++ b/.github/workflows/v2-prepare-scoring.yml
@@ -7,7 +7,7 @@ on:
 
 jobs: 
   scoring:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Set start timestamp
@@ -15,7 +15,7 @@ jobs:
         start_timestamp=$(date +%s)
         echo "start_timestamp=$start_timestamp" >> $GITHUB_ENV
 
-    - uses: actions/checkout@master
+    - uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
     - name: Prepare target directory
       run: |
         epoch_info=$(curl -sfLS "http://api.mainnet-beta.solana.com" -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1, "method":"getEpochInfo"}')
@@ -31,7 +31,7 @@ jobs:
         mkdir -p "$scoring_path"
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -39,7 +39,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
     - name: Configure image
       run: |

--- a/.github/workflows/v2-prepare-unstakes.yml
+++ b/.github/workflows/v2-prepare-unstakes.yml
@@ -6,11 +6,11 @@ on:
     types: [trigger_unstakes_v2]
 jobs: 
   unstakes:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@master
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       with:
         fetch-depth: 20
 
@@ -38,7 +38,7 @@ jobs:
         echo "scoring_id=$scoring_run_ui_id" >> $GITHUB_ENV
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -46,7 +46,7 @@ jobs:
 
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@5a88a04c91d5c6f97aae0d9be790e64d9b1d47b7 # v1
 
     - name: Configure image
       run: |

--- a/.github/workflows/v2-schedule-scoring.yml
+++ b/.github/workflows/v2-schedule-scoring.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   trigger_scoring_v2_if_needed:
     name: Schedule Scoring V2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@master
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       with:
         fetch-depth: 20
     - name: Check epoch timing

--- a/.github/workflows/v2-schedule-unstakes.yml
+++ b/.github/workflows/v2-schedule-unstakes.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   trigger_unstakes_v2_if_needed:
     name: Schedule Unstakes V2
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout the repository
-      uses: actions/checkout@master
+      uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # master
       with:
         fetch-depth: 20
     - name: Check epoch timing


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to immutable commit SHAs to prevent supply chain attacks
- Replace  with  for reproducible runner environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)