### PR TITLE
[github] dependabot actions version check [GEN-7618]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- Add dependabot configuration for GitHub Actions version monitoring
- Monthly checks for action updates, grouped into single PRs
- Part of GEN-7618: add dependabot GitHub Actions version check across marinade-finance repos

## Test plan
- [ ] Verify dependabot.yml is correctly formatted
- [ ] Verify dependabot picks up the configuration and starts monitoring